### PR TITLE
Support V5 Format and add humidity, pressure, battery and txPower properties

### DIFF
--- a/src/ruuvitag-adapter.ts
+++ b/src/ruuvitag-adapter.ts
@@ -13,6 +13,10 @@ import { parse } from './ruuvitag-parser';
 
 export class RuuviTag extends Device {
   private temperatureProperty: Property;
+  private humidityProperty: Property;
+  private pressureProperty: Property;
+  private batteryProperty: Property;
+  private txPowerProperty: Property;
 
   constructor(adapter: Adapter, manifest: any, id: string, address?: string) {
     super(adapter, `${RuuviTag.name}-${id}`);
@@ -32,17 +36,76 @@ export class RuuviTag extends Device {
       description: 'The ambient temperature',
       readOnly: true
     });
-
     this.properties.set('temperature', this.temperatureProperty);
+
+    this.humidityProperty = new Property(this, 'humidity', {
+      type: 'number',
+      unit: 'percent',
+      minimum: -1,
+      maximum: 101,
+      multipleOf: 0.01,
+      title: 'humidity',
+      description: 'The relative humidity',
+      readOnly: true
+    });
+    this.properties.set('humidity', this.humidityProperty);
+
+    this.pressureProperty = new Property(this, 'pressure', {
+        type: 'number',
+        minimum: 800,
+        maximum: 1200,
+        unit: 'Pa',
+        multipleOf: 0.01,
+        title: 'pressure',
+        description: 'The atmosperic pressure in pascals',
+        readOnly: true
+    });
+    this.properties.set('pressure', this.pressureProperty);
+
+    this.batteryProperty = new Property(this, 'battery', {
+        '@type': 'VoltageProperty',
+        type: 'number',
+        unit: 'volt',
+        minimum: 1.5,
+        maximum: 3.7,
+        multipleOf: 0.001,
+        title: 'battery',
+        description: 'The battery voltage',
+        readOnly: true
+    });
+    this.properties.set('battery', this.batteryProperty);
+
+    this.txPowerProperty = new Property(this, 'txPower', {
+        type: 'integer',
+        unit: 'dBm',
+        minimum: -40,
+        maximum: 20,
+        title: 'transmission power',
+        description: 'The transmission power in decibels',
+        readOnly: true
+    });
+    this.properties.set('txPower', this.txPowerProperty);
   }
 
   setData(manufacturerData: Buffer) {
     const {
-      temperature
+      temperature,
+      humidity,
+      pressure,
+      batteryVoltage,
+      txPower,
     } = parse(manufacturerData);
 
     this.temperatureProperty.setCachedValue(temperature);
     this.notifyPropertyChanged(this.temperatureProperty);
+    this.humidityProperty.setCachedValue(humidity);
+    this.notifyPropertyChanged(this.humidityProperty);
+    this.pressureProperty.setCachedValue(pressure);
+    this.notifyPropertyChanged(this.pressureProperty);
+    this.batteryProperty.setCachedValue(batteryVoltage);
+    this.notifyPropertyChanged(this.batteryProperty);
+    this.txPowerProperty.setCachedValue(txPower);
+    this.notifyPropertyChanged(this.txPowerProperty);
   }
 }
 

--- a/src/ruuvitag-parser.ts
+++ b/src/ruuvitag-parser.ts
@@ -22,19 +22,19 @@ export function parse(manufacturerData: Buffer) {
     }
 
     if (manufacturerData[2]===5) {
-        if (manufacturerData.readInt16BE(3)!==32767) {
+        if (manufacturerData.readInt16BE(3)!==0x8000) {
             temperature = manufacturerData.readInt16BE(3) / 200;
         }
 
-        if (manufacturerData.readUInt16BE(5)!==65536) {
+        if (manufacturerData.readUInt16BE(5)!==65535) {
             humidity = manufacturerData.readUInt16BE(5) / 400;
         }
 
-        if (manufacturerData.readUInt16BE(7)!==65536) {
+        if (manufacturerData.readUInt16BE(7)!==65535) {
             pressure = manufacturerData.readUInt16BE(7) / 10 - 4000;
         }
 
-        if (manufacturerData.readUInt16BE(15)!==65536) {
+        if (manufacturerData.readUInt16BE(15)!==65535) {
             const powerInfo = manufacturerData.readUInt16BE(15);
             batteryVoltage = (powerInfo >>> 5) / 1000.0 + 1.6;
             txPower = (powerInfo & 0b11111) * 2 - 40;

--- a/src/ruuvitag-parser.ts
+++ b/src/ruuvitag-parser.ts
@@ -31,7 +31,7 @@ export function parse(manufacturerData: Buffer) {
         }
 
         if (manufacturerData.readUInt16BE(7)!==65535) {
-            pressure = manufacturerData.readUInt16BE(7) / 10 - 4000;
+            pressure = manufacturerData.readUInt16BE(7) / 100 + 500;
         }
 
         if (manufacturerData.readUInt16BE(15)!==65535) {


### PR DESCRIPTION
This adds support for the new broadcast RAWv2 format / format 5 and adds properties for humidity, pressure, battery and txPower.
- I checked that all properties update in line with the values seen in the phone app.
- I don't have a tag with the old RAWv1 / format 3 firmware, so can't be specific on the version check and can't do the conversions for the additional properties. Please see if you can improve the version check for firmware version that you have?
- There are some areas where the data received does not agree with the specification. Notably the data offsets are out by 2. 
- There are further properties that may be useful to others, particularly the acceleration. If this PR works out, I can look at those properties later.
![RuuviTag](https://user-images.githubusercontent.com/65324897/84492093-2f052080-acd8-11ea-94f1-727948f37f1c.png)